### PR TITLE
feat: applied facade pattern to dao and dto

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="f9f0ac67-0bc5-492a-9e82-63193130dcba" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/com/dsa/generics/school/data/AbstractDataAccessObject.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/com/dsa/generics/school/data/DataAccessObject.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/com/dsa/generics/school/data/DataTransferObject.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/com/dsa/generics/school/data/Main.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/com/dsa/generics/school/data/User.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/com/dsa/hashmap/countries/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/com/dsa/hashmap/countries/Main.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -164,7 +168,8 @@
       <workItem from="1684839768551" duration="14000" />
       <workItem from="1684840189613" duration="41000" />
       <workItem from="1684840348808" duration="46000" />
-      <workItem from="1684930208964" duration="475000" />
+      <workItem from="1684930208964" duration="2315000" />
+      <workItem from="1685619470768" duration="527000" />
     </task>
     <servers />
   </component>

--- a/src/com/dsa/generics/school/data/AbstractDataAccessObject.java
+++ b/src/com/dsa/generics/school/data/AbstractDataAccessObject.java
@@ -1,0 +1,20 @@
+package com.dsa.generics.school.data;
+
+public abstract class AbstractDataAccessObject<T extends DataTransferObject> {
+
+    public boolean create() {
+        return false;
+    }
+
+    public boolean delete() {
+        return false;
+    }
+
+    public boolean put() {
+        return false;
+    }
+
+    public boolean update() {
+        return false;
+    }
+}

--- a/src/com/dsa/generics/school/data/DataAccessObject.java
+++ b/src/com/dsa/generics/school/data/DataAccessObject.java
@@ -1,0 +1,8 @@
+package com.dsa.generics.school.data;
+
+public class DataAccessObject extends AbstractDataAccessObject {
+
+    DataAccessObject() {
+        super();
+    }
+}

--- a/src/com/dsa/generics/school/data/DataTransferObject.java
+++ b/src/com/dsa/generics/school/data/DataTransferObject.java
@@ -1,0 +1,6 @@
+package com.dsa.generics.school.data;
+
+public interface DataTransferObject<T> {
+
+    public int getInt();
+}

--- a/src/com/dsa/generics/school/data/Main.java
+++ b/src/com/dsa/generics/school/data/Main.java
@@ -1,0 +1,8 @@
+package com.dsa.generics.school.data;
+
+public class Main {
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/src/com/dsa/generics/school/data/User.java
+++ b/src/com/dsa/generics/school/data/User.java
@@ -1,0 +1,9 @@
+package com.dsa.generics.school.data;
+
+public class User implements DataTransferObject {
+
+    @Override
+    public int getInt() {
+        return 0;
+    }
+}


### PR DESCRIPTION
**Description:** We want to be in a position whereby in the future if we have more model classes (Let's say User or Product) we can separate the database layer complexity from the controller class and let the DataAccessLayer (DAO) and DataTransferObject (DTO) handle it.

The DTO simply gets the id of any class that implements it's interface and allows the DAO to use that class when performing db operations. 